### PR TITLE
Prevents upward tick when there's only one child branch

### DIFF
--- a/process_diagram.css
+++ b/process_diagram.css
@@ -60,6 +60,8 @@
 .process_diagram ul > li:first-child:after {top:50%; bottom:auto; height:50%; }
 .process_diagram ul > li:last-child:before,
 .process_diagram ul > li:last-child:after {top:0; bottom:auto; height:50%;}
+.process_diagram ul > li:first-child:last-child:before,
+.process_diagram ul > li:first-child:last-child:after {top:0; bottom:auto; height:50%;}
 
 /* put left and right dashes */
 .process_diagram li > div {position:relative; margin:0 var(--linewidth); padding: 1em; border-width:var(--linethick); }


### PR DESCRIPTION
Does what it says on the tin! I noticed I was getting unneeded vertical lines created by the last-child on ul > li when I only had one child. first-child:last-child sets the height of those to 0 to hide them.